### PR TITLE
Update sbatch_fmriprep.sh

### DIFF
--- a/sbatch/sbatch_fmriprep.sh
+++ b/sbatch/sbatch_fmriprep.sh
@@ -2,8 +2,8 @@
 #SBATCH --job-name=fmriprep
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus=32
-#SBATCH --mem=128G
+#SBATCH --cpus=8
+#SBATCH --mem=32G
 #SBATCH --time=24:00:00
 #SBATCH --account=def-mathroy
 #SBATCH --mail-user=christophe.tanguaysabourin@mail.mcgill.ca
@@ -19,8 +19,9 @@ module load singularity/3.2
 singularity run --cleanenv --bind /home/tangsab8/projects/ctb-mathroy/tangsab8/CLBP_Network_Project/Placebo_1_Data_Copy:/data \
 --bind /home/tangsab8/projects/ctb-mathroy/tangsab8/CLBP_Network_Project/FMRIPREP_OUTPUT:/out \
 /home/tangsab8/projects/ctb-mathroy/tangsab8/CLBP_Network_Project/fmriprep.1.4.1.simg \
---ignore slicetiming
---participant-label <SUBJECT> \
--w /home/tangsab8/scratch \
---fs-license-file '/home/tangsab8/projects/ctb-mathroy/tangsab8/CLBP_Network/license.txt' \
+--participant-label 001 \
+--ignore slicetiming \
+--output-spaces 'MNI152NLin6Asym' 'T1w' \
+--fs-license-file '/home/tangsab8/projects/ctb-mathroy/tangsab8/CLBP_Network_Project/license.txt' \
+-w ~/home/tangsab8/scratch \
 /data /out participant


### PR DESCRIPTION
Tried out manually on different commands on my terminal, it seems that ~home/account/scratch was the proper directory and that participant label was with a -, not a _.